### PR TITLE
Remove JSON parsing

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -58,19 +58,22 @@ jobs:
           echo "NETLIFY_PROD_URL: ${{ steps.netlify.outputs.NETLIFY_PROD_URL }}"
 
   deploy-draft-new:
-    name: draft via South-Paw/action-netlify-cli@main
+    name: draft via South-Paw/action-netlify-cli
     runs-on: ubuntu-latest
     needs:
       - deploy-draft-original
       - deploy-prod-original
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Generate HTML document
         run: |
           mkdir -p example
           echo -e "<pre>$(date -u)\n$GITHUB_SHA\n$GITHUB_REF</pre>" > example/index.html
 
       - name: Deploy draft to Netlify
-        uses: South-Paw/action-netlify-cli@main
+        uses: ./
         id: netlify
         with:
           args: 'deploy --json --dir \"./example\" --message \"draft [${{ github.sha }}]\"'
@@ -86,19 +89,22 @@ jobs:
           echo "NETLIFY_PROD_URL: ${{ steps.netlify.outputs.NETLIFY_PROD_URL }}"
 
   deploy-prod-new:
-    name: production via South-Paw/action-netlify-cli@main
+    name: production via South-Paw/action-netlify-cli
     runs-on: ubuntu-latest
     needs:
       - deploy-draft-original
       - deploy-prod-original
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Generate HTML document
         run: |
           mkdir -p example
           echo -e "<pre>$(date -u)\n$GITHUB_SHA\n$GITHUB_REF</pre>" > example/index.html
 
       - name: Deploy to Netlify
-        uses: South-Paw/action-netlify-cli@main
+        uses: ./
         id: netlify
         with:
           args: 'deploy --json --prod --dir \"./example\" --message \"production [${{ github.sha }}]\"'

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -28,9 +28,6 @@ jobs:
       - name: Action outputs
         run: |
           echo "NETLIFY_OUTPUT: ${{ steps.netlify.outputs.NETLIFY_OUTPUT }}"
-          echo "NETLIFY_LOGS_URL: ${{ steps.netlify.outputs.NETLIFY_LOGS_URL }}"
-          echo "NETLIFY_DRAFT_URL: ${{ steps.netlify.outputs.NETLIFY_DRAFT_URL }}"
-          echo "NETLIFY_PROD_URL: ${{ steps.netlify.outputs.NETLIFY_PROD_URL }}"
 
   deploy-prod-original:
     name: production via netlify/actions/cli@master
@@ -53,9 +50,6 @@ jobs:
       - name: Action outputs
         run: |
           echo "NETLIFY_OUTPUT: ${{ steps.netlify.outputs.NETLIFY_OUTPUT }}"
-          echo "NETLIFY_LOGS_URL: ${{ steps.netlify.outputs.NETLIFY_LOGS_URL }}"
-          echo "NETLIFY_DRAFT_URL: ${{ steps.netlify.outputs.NETLIFY_DRAFT_URL }}"
-          echo "NETLIFY_PROD_URL: ${{ steps.netlify.outputs.NETLIFY_PROD_URL }}"
 
   deploy-draft-new:
     name: draft via South-Paw/action-netlify-cli
@@ -84,9 +78,6 @@ jobs:
       - name: Action outputs
         run: |
           echo "NETLIFY_OUTPUT: ${{ steps.netlify.outputs.NETLIFY_OUTPUT }}"
-          echo "NETLIFY_LOGS_URL: ${{ steps.netlify.outputs.NETLIFY_LOGS_URL }}"
-          echo "NETLIFY_DRAFT_URL: ${{ steps.netlify.outputs.NETLIFY_DRAFT_URL }}"
-          echo "NETLIFY_PROD_URL: ${{ steps.netlify.outputs.NETLIFY_PROD_URL }}"
 
   deploy-prod-new:
     name: production via South-Paw/action-netlify-cli
@@ -115,6 +106,3 @@ jobs:
       - name: Action outputs
         run: |
           echo "NETLIFY_OUTPUT: ${{ steps.netlify.outputs.NETLIFY_OUTPUT }}"
-          echo "NETLIFY_LOGS_URL: ${{ steps.netlify.outputs.NETLIFY_LOGS_URL }}"
-          echo "NETLIFY_DRAFT_URL: ${{ steps.netlify.outputs.NETLIFY_DRAFT_URL }}"
-          echo "NETLIFY_PROD_URL: ${{ steps.netlify.outputs.NETLIFY_PROD_URL }}"

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+  workflow_dispatch:
 
 jobs:
   deploy-draft-original:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,13 +11,16 @@ jobs:
     name: draft
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Generate HTML document
         run: |
           mkdir -p example
           echo -e "<pre>$(date -u)\n$GITHUB_SHA\n$GITHUB_REF</pre>" > example/index.html
 
       - name: Deploy draft to Netlify
-        uses: South-Paw/action-netlify-cli@main
+        uses: ./
         id: netlify
         with:
           args: 'deploy --json --dir \"./example\" --message \"draft [${{ github.sha }}]\"'
@@ -36,13 +39,16 @@ jobs:
     name: production
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Generate HTML document
         run: |
           mkdir -p example
           echo -e "<pre>$(date -u)\n$GITHUB_SHA\n$GITHUB_REF</pre>" > example/index.html
 
       - name: Deploy to Netlify
-        uses: South-Paw/action-netlify-cli@main
+        uses: ./
         id: netlify
         with:
           args: 'deploy --prod --json --dir \"./example\" --message \"production [${{ github.sha }}]\"'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches-ignore:
-      - "master"
+      - "main"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - "master"
+  workflow_dispatch:
 
 jobs:
   deploy-draft-new:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,9 +31,6 @@ jobs:
       - name: Action outputs
         run: |
           echo "NETLIFY_OUTPUT: ${{ steps.netlify.outputs.NETLIFY_OUTPUT }}"
-          echo "NETLIFY_LOGS_URL: ${{ steps.netlify.outputs.NETLIFY_LOGS_URL }}"
-          echo "NETLIFY_DRAFT_URL: ${{ steps.netlify.outputs.NETLIFY_DRAFT_URL }}"
-          echo "NETLIFY_PROD_URL: ${{ steps.netlify.outputs.NETLIFY_PROD_URL }}"
 
   deploy-prod-new:
     name: production
@@ -59,6 +56,3 @@ jobs:
       - name: Action outputs
         run: |
           echo "NETLIFY_OUTPUT: ${{ steps.netlify.outputs.NETLIFY_OUTPUT }}"
-          echo "NETLIFY_LOGS_URL: ${{ steps.netlify.outputs.NETLIFY_LOGS_URL }}"
-          echo "NETLIFY_DRAFT_URL: ${{ steps.netlify.outputs.NETLIFY_DRAFT_URL }}"
-          echo "NETLIFY_PROD_URL: ${{ steps.netlify.outputs.NETLIFY_PROD_URL }}"

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Netlify CLI"
-description: "Wraps the Netlify CLI and offers access to deploy outputs"
+description: "Fast Netlify CLI wrapper with output"
 author: "Alex Gabites <https://github.com/South-Paw>"
 branding:
   color: purple

--- a/action.yml
+++ b/action.yml
@@ -18,12 +18,3 @@ outputs:
   NETLIFY_OUTPUT:
     description: "Raw Netlify CLI output message"
     value: ${{ steps.script.outputs.NETLIFY_OUTPUT }}
-  NETLIFY_LOGS_URL:
-    description: "URL to Netlify deployment logs"
-    value: ${{ fromJson(steps.script.outputs.NETLIFY_OUTPUT).logs }}
-  NETLIFY_DRAFT_URL:
-    description: "URL to draft site"
-    value: ${{ fromJson(steps.script.outputs.NETLIFY_OUTPUT).deploy_url }}
-  NETLIFY_PROD_URL:
-    description: "URL to production site"
-    value: ${{ fromJson(steps.script.outputs.NETLIFY_OUTPUT).url }}


### PR DESCRIPTION
Removed the `NETLIFY_LOGS_URL`, `NETLIFY_DRAFT_URL` and `NETLIFY_PROD_URL` outputs as if the user is not using `deploy --json` this action will fail.

You can still access these outputs yourself however if you were using them. See the [**"Parse `--json` flag"**](https://github.com/South-Paw/action-netlify-cli#parse---json-flag) recipe in the README